### PR TITLE
Power:MSM8916:Build Errors Fix

### DIFF
--- a/power-8916.c
+++ b/power-8916.c
@@ -76,7 +76,7 @@ static bool is_target_8916(void)
     return is_8916;
 }
 
-int power_hint_override(power_hint_t hint, void *data)
+int power_hint_override(power_hint_t hint)
 {
     switch (hint) {
         case POWER_HINT_VSYNC:


### PR DESCRIPTION
hardware/qcom/power/power-8916.c:79:50: error: unused parameter 'data' [-Werror,-Wunused-parameter]
int power_hint_override(power_hint_t hint, void *data)